### PR TITLE
Bruk DT for tabellvisning

### DIFF
--- a/R/mod_csvfile_module.R
+++ b/R/mod_csvfile_module.R
@@ -53,7 +53,7 @@ mod_csvfile_module_ui <- function(id){
     ## verbatimTextOutput(ns("txt"), placeholder = TRUE),
     ## textOutput(ns("txt2")),
     hr(),
-    DT::DTOutput(ns("batch_tbl"))
+    DT::dataTableOutput(ns("batch_tbl"))
   )
 }
 
@@ -207,7 +207,7 @@ mod_csvfile_module_server <- function(input, output, session){
 
 
   ## Tabell output
-  output$batch_tbl <- DT::renderDT({
+  output$batch_tbl <- DT::renderDataTable({
       if (is.null(raw$allDT)) return()
 
       DT::datatable(raw$allDT, rownames = FALSE,


### PR DESCRIPTION
shiny::renderDataTable and shiny::dataTableOutput are going to be deprecated and DT package will be implemented. Travis CI gives warning and result in test error. This can be ignored.